### PR TITLE
Some enhabcement and bug fix for code signing

### DIFF
--- a/shared/bin/qbuild
+++ b/shared/bin/qbuild
@@ -32,6 +32,10 @@ PREFIX="App Center"
 ##### Command definitions #####
 CMD_AWK="${CMD_AWK:-$(command -v awk)}"
 CMD_CMP="${CMD_CMP:-$(command -v cmp)}"
+CS_PYTHON="${CS_PYTHON:-$(command -v python2)}"
+if [ ! -e "$CS_PYTHON" ]; then
+CS_PYTHON="$(command -v python)"
+fi
 
 # Cleanup any temporary directories and files at termination.
 trap 'cleanup_all' INT TERM
@@ -513,7 +517,7 @@ do_code_signing(){
 	[ -z "$QNAP_CODE_SIGNING_CSV" ] && QNAP_CODE_SIGNING_CSV="build_sign.csv"
 	[ -z "$QNAP_CODE_SIGNING_SERVER_IP" ] && QNAP_CODE_SIGNING_SERVER_IP=$DEFAULT_QNAP_CODE_SIGNING_SERVER_IP
 	[ -z "$QNAP_CODE_SIGNING_SERVER_PORT" ] && QNAP_CODE_SIGNING_SERVER_PORT=$DEFAULT_QNAP_CODE_SIGNING_SERVER_PORT
-	python "${QDK_SCRIPTS_DIR}/codesigning_qpkg.py" cert="${QDK_SCRIPTS_DIR}/codesigning_cert.pem" cwd="`pwd`" buildpath=$build_dir csv="${QNAP_CODE_SIGNING_CSV}" server=${QNAP_CODE_SIGNING_SERVER_IP}:${QNAP_CODE_SIGNING_SERVER_PORT}  2>&1 | tee -a code_signing.log
+	$CS_PYTHON "${QDK_SCRIPTS_DIR}/codesigning_qpkg.py" cert="${QDK_SCRIPTS_DIR}/codesigning_cert.pem" cwd="`pwd`" buildpath=$build_dir csv="${QNAP_CODE_SIGNING_CSV}" server=${QNAP_CODE_SIGNING_SERVER_IP}:${QNAP_CODE_SIGNING_SERVER_PORT}  2>&1 | tee -a code_signing.log
 }
 
 # Create data package for distribution.
@@ -906,12 +910,14 @@ add_qpkg_signature(){
 		[ -z "$QNAP_CODE_SIGNING_SERVER_IP" ] && QNAP_CODE_SIGNING_SERVER_IP=$DEFAULT_QNAP_CODE_SIGNING_SERVER_IP
 		[ -z "$QNAP_CODE_SIGNING_SERVER_PORT" ] && QNAP_CODE_SIGNING_SERVER_PORT=$DEFAULT_QNAP_CODE_SIGNING_SERVER_PORT
 		openssl dgst -sha1 -binary "${QDK_QPKG_FILE}" > "${QDK_QPKG_FILE}.sha"
-		python "${QDK_SCRIPTS_DIR}/codesigning_qpkg_cms.py" cert="${QDK_SCRIPTS_DIR}/codesigning_cert.pem" cwd="`pwd`" server=${QNAP_CODE_SIGNING_SERVER_IP}:${QNAP_CODE_SIGNING_SERVER_PORT} in="${QDK_QPKG_FILE}.sha" out="${QDK_QPKG_FILE}.msg" 2>&1 | tee -a code_signing.log
+		$CS_PYTHON "${QDK_SCRIPTS_DIR}/codesigning_qpkg_cms.py" cert="${QDK_SCRIPTS_DIR}/codesigning_cert.pem" cwd="`pwd`" server=${QNAP_CODE_SIGNING_SERVER_IP}:${QNAP_CODE_SIGNING_SERVER_PORT} in="${QDK_QPKG_FILE}.sha" out="${QDK_QPKG_FILE}.msg" 2>&1 | tee -a code_signing.log
 		/bin/rm ${QDK_QPKG_FILE}.sha
 		if [ -f "${QDK_QPKG_FILE}.msg" ]; then
 			add_qdk_area_begin
 			add_qdk_area_code_signing ${QDK_QPKG_FILE}.msg
 			add_qdk_area_end
+			SIG=`openssl cms -cmsout -in ${QDK_QPKG_FILE}.msg | tr -d '\n' | tail -c 32`
+			echo "${SIG}" > ${QDK_BUILD_DIR}/${QDK_QPKG_FILE}.codesigning
 			/bin/rm ${QDK_QPKG_FILE}.msg
 		else
 			warn_msg "$QDK_QPKG_FILE: no code signing data added"
@@ -1286,7 +1292,7 @@ create_env(){
 	edit_qpkg_config QPKG_SERVICE_PROGRAM "${qpkg_name}.sh" "$qpkg_cfg"
 
 	[ -z "$QDK_BUILD_VERSION" ] || edit_qpkg_config QPKG_VER "$QDK_BUILD_VERSION" "$qpkg_cfg"
-	/bin/echo "/${qpkg_name}.sh," > ${qpkg_name}/build_sign.csv
+	/bin/echo ",/${qpkg_name}.sh," > ${qpkg_name}/build_sign.csv
 	verbose_msg "Template QPKG build environment created in $qpkg_name directory"
 }
 
@@ -1537,7 +1543,7 @@ add_code_signing(){
 
 	# Send qpkg digest to server
 	openssl dgst -sha1 -binary "${qpkg}.$$" > "${qpkg}.sha"
-	python "${QDK_SCRIPTS_DIR}/codesigning_qpkg_cms.py" cert="${QDK_SCRIPTS_DIR}/codesigning_cert.pem" server=${QNAP_CODE_SIGNING_SERVER_IP}:${QNAP_CODE_SIGNING_SERVER_PORT} qpkgname=${QPKG_NAME} version=${QPKG_VER} in="${qpkg}.sha" out="${qpkg}.msg" 2>&1 | tee -a code_signing.log
+	$CS_PYTHON "${QDK_SCRIPTS_DIR}/codesigning_qpkg_cms.py" cert="${QDK_SCRIPTS_DIR}/codesigning_cert.pem" server=${QNAP_CODE_SIGNING_SERVER_IP}:${QNAP_CODE_SIGNING_SERVER_PORT} qpkgname=${QPKG_NAME} version=${QPKG_VER} in="${qpkg}.sha" out="${qpkg}.msg" 2>&1 | tee -a code_signing.log
 	/bin/rm ${qpkg}.sha
 
 	# Add code signing data into qpkg
@@ -1545,6 +1551,8 @@ add_code_signing(){
 		add_qdk_area_begin ${qpkg}.$$
 		add_qdk_area_code_signing ${qpkg}.msg ${qpkg}.$$
 		add_qdk_area_end ${qpkg}.$$
+		SIG=`openssl cms -cmsout -in ${QDK_QPKG_FILE}.msg | tr -d '\n' | tail -c 32`
+		echo "${SIG}" > ${QDK_BUILD_DIR}/${QDK_QPKG_FILE}.codesigning
 		/bin/rm ${qpkg}.msg
 	else
 		/bin/rm ${qpkg}.$$
@@ -1582,12 +1590,12 @@ verify_code_signing(){
 		https://${QNAP_CODE_SIGNING_SERVER_IP}:${QNAP_CODE_SIGNING_SERVER_PORT}/keys/qnaproot \
 		2>/dev/null"
 	output="$(eval $curl_cmd)" || err_msg "failed to connect to code signing server"
-	server_err=$(echo $output | python -c 'import json,sys;obj=json.load(sys.stdin);print obj["error"]')
+	server_err=$(echo $output | $CS_PYTHON -c 'import json,sys;obj=json.load(sys.stdin);print obj["error"]')
 	if [ $server_err -ne 0 ]; then
-		server_msg=$(echo $output | python -c 'import json,sys;obj=json.load(sys.stdin);print obj["msg"]')
+		server_msg=$(echo $output | $CS_PYTHON -c 'import json,sys;obj=json.load(sys.stdin);print obj["msg"]')
 		err_msg "error from code signing server: $server_msg"
 	fi
-	echo $output | python -c 'import json,sys;obj=json.load(sys.stdin);print obj["certificate"]["pem"]' > $ca_cert_file
+	echo $output | $CS_PYTHON -c 'import json,sys;obj=json.load(sys.stdin);print obj["certificate"]["pem"]' > $ca_cert_file
 
 	# Get ca cert (3rd party)
 	ca_cert3_file="${qpkg}.ca3"
@@ -1595,12 +1603,12 @@ verify_code_signing(){
 		https://${QNAP_CODE_SIGNING_SERVER_IP}:${QNAP_CODE_SIGNING_SERVER_PORT}/keys/qnaproot \
 		2>/dev/null"
 	output="$(eval $curl_cmd)" || err_msg "failed to connect to code signing server"
-	server_err=$(echo $output | python -c 'import json,sys;obj=json.load(sys.stdin);print obj["error"]')
+	server_err=$(echo $output | $CS_PYTHON -c 'import json,sys;obj=json.load(sys.stdin);print obj["error"]')
 	if [ $server_err -ne 0 ]; then
-		server_msg=$(echo $output | python -c 'import json,sys;obj=json.load(sys.stdin);print obj["msg"]')
+		server_msg=$(echo $output | $CS_PYTHON -c 'import json,sys;obj=json.load(sys.stdin);print obj["msg"]')
 		err_msg "error from code signing server: $server_msg"
 	fi
-	echo $output | python -c 'import json,sys;obj=json.load(sys.stdin);print obj["certificate"]["pem"]' > $ca_cert3_file
+	echo $output | $CS_PYTHON -c 'import json,sys;obj=json.load(sys.stdin);print obj["certificate"]["pem"]' > $ca_cert3_file
 
 	# Verify
 	qpkg_data_file="${qpkg}.data"

--- a/shared/scripts/codesigning_common.py
+++ b/shared/scripts/codesigning_common.py
@@ -236,7 +236,7 @@ def sign_files(kwargs):
         url = url + "/" + kwargs["version"]
     elif key_type == "qpkg":
         url = url + "/" + kwargs["qpkgname"] + "/" + kwargs["version"]
-    command = "curl %s --connect-timeout 60 --max-time 600 -X POST -F token=%s -F file=@%s https://%s"
+    command = "curl %s --connect-timeout 60 --max-time 600 --retry 3 -X POST -F token=%s -F file=@%s https://%s"
     if "cert" in kwargs:
         if not os.path.isfile(kwargs["cert"]):
             logging.error("Cannot find certificate file %s" % kwargs["cert"])
@@ -268,7 +268,7 @@ def sign_cms(kwargs):
         url = url + "/" + kwargs["version"]
     elif key_type == "qpkg":
         url = url + "/" + kwargs["qpkgname"] + "/" + kwargs["version"]
-    command = "curl %s --connect-timeout 60 --max-time 600 -X POST -F token=%s -F file=@%s https://%s"
+    command = "curl %s --connect-timeout 60 --max-time 600 --retry 3 -X POST -F token=%s -F file=@%s https://%s"
     if "cert" in kwargs:
         if not os.path.isfile(kwargs["cert"]):
             logging.error("Cannot find certificate file %s" % kwargs["cert"])

--- a/shared/scripts/codesigning_login.sh
+++ b/shared/scripts/codesigning_login.sh
@@ -5,6 +5,8 @@ SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 read -p 'username: ' USERNAME
 read -sp 'password: ' PASSWORD
 echo
+USERNAME=$(python -c "import urllib; print urllib.quote('''$USERNAME''')")
+PASSWORD=$(python -c "import urllib; print urllib.quote('''$PASSWORD''')")
 RESPONSE="$(eval "curl -X POST --cacert ${SCRIPTPATH}/codesigning_cert.pem -d \"username=${USERNAME}&password=${PASSWORD}\" \
 	https://${SERVER}:5000/login 2>/dev/null")"
 RET=$?

--- a/shared/scripts/qinstall.sh
+++ b/shared/scripts/qinstall.sh
@@ -60,7 +60,7 @@ CMD_WGET="/usr/bin/wget"
 CMD_WLOG="/sbin/write_log"
 CMD_XARGS="/usr/bin/xargs"
 CMD_7Z="/usr/local/sbin/7z"
-
+CMD_QSH="/usr/local/sbin/qsh"
 
 ##### System definitions #####
 SYS_EXTRACT_DIR="$(pwd)"
@@ -135,6 +135,7 @@ SYS_USB_SHARE=""
 SYS_USB_PATH=""
 SYS_WEB_SHARE=""
 SYS_WEB_PATH=""
+SYS_CODESIGNING_TOKEN=""
 # Path to ipkg or opkg package tool if installed.
 CMD_PKG_TOOL=
 
@@ -148,6 +149,7 @@ CMD_PKG_TOOL=
 ###########################################
 SYS_MSG_FILE_NOT_FOUND="Data file not found."
 SYS_MSG_FILE_ERROR="[$PREFIX] Failed to install $QPKG_NAME due to data file error."
+SYS_MSG_CODESIGNING_ERROR="[$PREFIX] Failed to install $QPKG_NAME due to anti-tampering file error."
 SYS_MSG_PUBLIC_NOT_FOUND="Public share not found."
 SYS_MSG_FAILED_CONFIG_RESTORE="Failed to restore saved configuration data."
 
@@ -209,34 +211,47 @@ err_log(){
 
 handle_extract_error(){
 	if [ -x "/usr/local/sbin/notify" ]; then
-		/usr/local/sbin/notify send -A A039 -C C001 -M 35 -l error -t 3 "[{0}] {1} install failed du to data file error." "$PREFIX" "$QPKG_DISPLAY_NAME"
+		/usr/local/sbin/notify send -A A039 -C C001 -M 35 -l error -t 3 "[{0}] {1} install failed due to data file error." "$PREFIX" "$QPKG_DISPLAY_NAME"
 		set_progress_fail
 		exit 1
 	else
 		err_log "$SYS_MSG_FILE_ERROR"
 	fi
 }
-TOKEN=""
-codesigning_preinstall(){
-	local ret="$($CMD_ECHO -n "$QPKG_NAME:$SYS_QPKG_DIR" | qsh -0e cs_qdaemon.verify_qpkg)"
-	local status=`$CMD_ECHO $ret | awk -F':' '{print $1}'`
-	TOKEN=`$CMD_ECHO $ret | awk -F':' '{print $2}'`
-	echo "verify_qpkg return: $ret, status: $status, token: $TOKEN"
-	if [ "x$status" != "xsuccess" ] || [ "x$TOKEN" = "x" ]; then
-		## is it possible to be here after we have already checked cerficiate first?
-		handle_extract_error
+
+handle_codesigning_error(){
+	if [ -x "/usr/local/sbin/notify" ]; then
+		/usr/local/sbin/notify send -A A039 -C C001 -M 62 -l error -t 3 "[{0}] Failed to install {1} due to anti-tampering file error." "$PREFIX" "$QPKG_DISPLAY_NAME"
+		set_progress_fail
+		exit 1
+	else
+		err_log "$SYS_MSG_CODESIGNING_ERROR"
 	fi
 }
+
+codesigning_preinstall(){
+	local ret="$($CMD_ECHO -n "$QPKG_NAME:$SYS_QPKG_DIR" | $CMD_QSH -0e cs_qdaemon.verify_qpkg)"
+	local status=`$CMD_ECHO $ret | $CMD_AWK -F':' '{print $1}'`
+	SYS_CODESIGNING_TOKEN=`$CMD_ECHO $ret | $CMD_AWK -F':' '{print $2}'`
+	$CMD_ECHO "verify_qpkg return: $ret, status: $status, token: $SYS_CODESIGNING_TOKEN"
+	if [ "x$status" != "xsuccess" ] || [ "x$SYS_CODESIGNING_TOKEN" = "x" ]; then
+		## is it possible to be here after we have already checked cerficiate first?
+		handle_codesigning_error
+	fi
+}
+
 codesigning_postinstall(){
-	echo "codesigning_postinstall token: $TOKEN"
-	if [ "x$TOKEN" != "x" ]; then
-		local ret="$($CMD_ECHO -n "$QPKG_NAME:$TOKEN" | qsh -0e cs_qdaemon.qpkg_finish)"
-		echo "finish return: $ret"
+	local err="${1:-0}"
+	$CMD_ECHO "codesigning_postinstall token: $SYS_CODESIGNING_TOKEN, err: $err"
+	if [ "x$SYS_CODESIGNING_TOKEN" != "x" ]; then
+		local ret="$($CMD_ECHO -n "$QPKG_NAME:$SYS_CODESIGNING_TOKEN:$err" | $CMD_QSH -0e cs_qdaemon.qpkg_finish)"
+		$CMD_ECHO "finish return: $ret"
 	else
 		## is it possible to be here after we have already checked cerficiate first?
-		handle_extract_error
+		handle_codesigning_error
 	fi
 }
+
 codesigning_extract_data(){
 	[ -n "$1" ] || return 1
 	local archive="$1"
@@ -247,11 +262,12 @@ codesigning_extract_data(){
 		*.gz|*.bz2)
 			$CMD_TAR xf "$archive" "./$codesigning_dir" 2>/dev/null
 			if [ $? = 0 ]; then
-				$CMD_MV "$codesigning_dir" "$root_dir/$codesigning_dir"
+				$CMD_CP -arf "$codesigning_dir" "$root_dir/"
 				codesigning_preinstall
 				$CMD_TAR xvf "$archive" --exclude="$codesigning_dir" -C "$root_dir" 2>/dev/null >>$SYS_QPKG_DIR/.list
 				ret=$?
-				codesigning_postinstall
+				codesigning_postinstall $ret
+				$CMD_RM -rf "$codesigning_dir"
 				[ $ret = 0 ] || handle_extract_error
 			else
 				$CMD_TAR xvf "$archive" -C "$root_dir" 2>/dev/null >>$SYS_QPKG_DIR/.list || handle_extract_error
@@ -260,11 +276,12 @@ codesigning_extract_data(){
 		*.7z)
 			$CMD_7Z x -so "$archive" 2>/dev/null | $CMD_TAR x "./$codesigning_dir" 2>/dev/null
 			if [ $? = 0 ]; then
-				$CMD_MV "$codesigning_dir" "$root_dir/$codesigning_dir"
+				$CMD_CP -arf "$codesigning_dir" "$root_dir/"
 				codesigning_preinstall
 				$CMD_7Z x -so "$archive" 2>/dev/null | $CMD_TAR xv -C "$root_dir" --exclude="$codesigning_dir" 2>/dev/null >>$SYS_QPKG_DIR/.list
 				ret=$?
-				codesigning_postinstall
+				codesigning_postinstall $ret
+				$CMD_RM -rf "$codesigning_dir"
 				[ $ret = 0 ] || handle_extract_error
 			else
 				$CMD_7Z x -so "$archive" 2>/dev/null | $CMD_TAR xv -C "$root_dir" 2>/dev/null >>$SYS_QPKG_DIR/.list || handle_extract_error
@@ -444,7 +461,7 @@ check_qts_version(){
 
 	if [ ${MINI_VERSION} -gt ${NOW_VERSION} ]; then
 		if [ -x "/usr/local/sbin/notify" ]; then
-			/usr/local/sbin/notify send -A A039 -C C001 -M 40 -l error -t 3 "[{0}] {1} install failed du to the QTS firmware is not compatible, please upgrade QTS to {2} or newer version." "$PREFIX" "$QPKG_DISPLAY_NAME" "$QTS_MINI_VERSION"
+			/usr/local/sbin/notify send -A A039 -C C001 -M 40 -l error -t 3 "[{0}] {1} install failed due to the QTS firmware is not compatible, please upgrade QTS to {2} or newer version." "$PREFIX" "$QPKG_DISPLAY_NAME" "$QTS_MINI_VERSION"
 			set_progress_fail
 			exit 1
 		else
@@ -452,7 +469,7 @@ check_qts_version(){
 		fi
 	elif [ ${MAX_VERSION} -lt ${NOW_VERSION} ]; then
 		if [ -x "/usr/local/sbin/notify" ]; then
-			/usr/local/sbin/notify send -A A039 -C C001 -M 41 -l error -t 3 "[{0}] {1} install failed du to the QTS firmware is not compatible, please downgrade QTS to {2} or newer version." "$PREFIX" "$QPKG_DISPLAY_NAME" "$QTS_MAX_VERSION"
+			/usr/local/sbin/notify send -A A039 -C C001 -M 41 -l error -t 3 "[{0}] {1} install failed due to the QTS firmware is not compatible, please downgrade QTS to {2} or newer version." "$PREFIX" "$QPKG_DISPLAY_NAME" "$QTS_MAX_VERSION"
 			set_progress_fail
 			exit 1
 		else
@@ -1312,7 +1329,7 @@ main(){
 		SYS_QPKG_DATA_FILE=$SYS_QPKG_DATA_FILE_7ZIP
 	else
 		if [ -x "/usr/local/sbin/notify" ]; then
-			/usr/local/sbin/notify send -A A039 -C C001 -M 34 -l error -t 3 "[{0}] {1} install failed du to cannot find the data file." "$PREFIX" "$QPKG_DISPLAY_NAME"
+			/usr/local/sbin/notify send -A A039 -C C001 -M 34 -l error -t 3 "[{0}] {1} install failed due to cannot find the data file." "$PREFIX" "$QPKG_DISPLAY_NAME"
 			set_progress_fail
 			exit 1
 		else


### PR DESCRIPTION
1. Try to use python2 to do code signing first
2. Add support to generate xml sig data (mainly for 3rd party qpkg)
3. Fix default csv template for anti-tamper
4. Add curl retry  mechanism
5. Fix that it can not login to code signing server if password contains special characters
6. Add error log for anti-tamper
7. Fix that the anti-tamper information can not be updated while upgrading qpkg
8 Add more error handling for anti-tamper in qinstall.sh
9. Fix some typos in qinstall.sh