### PR TITLE
fix: Use a unique folder to extract a qpkg when installing.

### DIFF
--- a/shared/bin/qbuild
+++ b/shared/bin/qbuild
@@ -695,7 +695,7 @@ add_qpkg_header(){
 	# Return value 0 to keep the QPKG package after installation
 	# Return value 10 to remove QPKG package after installation
 	local retval=10
-	local extract_dir="\$QPKG_INSTALL_PATH/.tmp"
+	local extract_dir="\$QPKG_INSTALL_PATH/.tmp-${QPKG_NAME}"
 	local wrong_arch="[$PREFIX] Failed to install $QPKG_DISPLAY_NAME $QPKG_VER. Installation package is incompatible. Use the correct package."
 	local log_tool="/sbin/log_tool -t2 -uSystem -p127.0.0.1 -mlocalhost -a"
 


### PR DESCRIPTION
This fixes a problem we ran into at Solink when building QPKGs.  We install QPKGs by running them as self-extracting archives:

```sh
sh Docker.qpkg
```

The problem is that the temporary folder that is used to unpack a qpkg while installing it is basically hard-coded into the qpkg file as `$QPKG_INSTALL_PATH/.tmp`, so if you try to install two different QPKGs from two different processes at the same time, they'll end up clobbering each other.  Often we'll see a qpkg get installed that is missing files, or which has files from another qpkg.

This fixes this problem by including the name of the qpkg in the temporary folder.