### PR TITLE
Add missing parameters for generating signature

### DIFF
--- a/InstallToUbuntu.sh
+++ b/InstallToUbuntu.sh
@@ -28,6 +28,7 @@ case "$1" in
 	;;
 	remove)
 		echo "Remove QDK"
+		rm -rf "/bin/qpkg_encrypt"
 		rm -rf "/etc/config/qdk.conf"
 		rm -rf "/usr/share/QDK"
 		sed -i '/QDK/d' ~/.bashrc

--- a/debian/qbuild.1
+++ b/debian/qbuild.1
@@ -148,8 +148,8 @@ output package specific functions
 .PP
 \fB\-\-sign\fR
 .IP
-Generate and insert digital signature to QPKG. By default the first key
-in the secret keyring is used.
+Generate and insert digital signature to QPKG using the public keyring
+specified by QDK_GPG_PUBKEYRING (default: /etc/config/qpkg.gpg).
 .PP
 \fB\-\-gpg\-name\fR ID
 .IP
@@ -162,7 +162,7 @@ Verify digital signature assigned to QPKG.
 \fB\-\-add\-sign\fR QPKG
 .IP
 Generate and insert digital signature to QPKG, replacing any existing
-signature.
+signature. Uses QDK_GPG_PUBKEYRING in the same way as \fB\-\-sign\fR.
 .PP
 \fB\-\-import\-key\fR KEY
 .IP

--- a/shared/bin/qbuild
+++ b/shared/bin/qbuild
@@ -1060,7 +1060,7 @@ add_qpkg_signature(){
 
 			case "$QDK_SIGNATURE" in
 				gpg)
-					local gpg_options="--detach-sign -o-"
+					local gpg_options="--no-default-keyring --keyring $QDK_GPG_PUBKEYRING --detach-sign -o-"
 					[ -n "$QDK_GPG_NAME" ] && gpg_options="$gpg_options -u $QDK_GPG_NAME"
 					is_quiet && gpg_options="$gpg_options --no-tty"
 					debug_msg "$QDK_GPG_APP $gpg_options $QDK_QPKG_FILE >> ${QDK_QPKG_FILE}.sig"
@@ -1592,7 +1592,7 @@ add_sign_qpkg(){
 			eval "$dd_cmd"
 
 			verbose_msg "Generate and add new signature..."
-			local gpg_options="--detach-sign -o-"
+			local gpg_options="--no-default-keyring --keyring $QDK_GPG_PUBKEYRING --detach-sign -o-"
 			[ -n "$QDK_GPG_NAME" ] && gpg_options="$gpg_options -u $QDK_GPG_NAME"
 			is_quiet && gpg_options="$gpg_options --no-tty"
 			gpg_cmd="$QDK_GPG_APP $gpg_options ${qpkg}.$$ >> ${qpkg}.sig"

--- a/shared/bin/qbuild
+++ b/shared/bin/qbuild
@@ -1060,7 +1060,7 @@ add_qpkg_signature(){
 
 			case "$QDK_SIGNATURE" in
 				gpg)
-					local gpg_options="--detach-sign -o-"
+					local gpg_options="--no-default-keyring --keyring $QDK_GPG_PUBKEYRING --detach-sign -o-"
 					[ -n "$QDK_GPG_NAME" ] && gpg_options="$gpg_options -u $QDK_GPG_NAME"
 					is_quiet && gpg_options="$gpg_options --no-tty"
 					debug_msg "$QDK_GPG_APP $gpg_options $QDK_QPKG_FILE >> ${QDK_QPKG_FILE}.sig"
@@ -1592,12 +1592,15 @@ add_sign_qpkg(){
 			eval "$dd_cmd"
 
 			verbose_msg "Generate and add new signature..."
-			local gpg_options="--detach-sign -o-"
+			local gpg_options="--no-default-keyring --keyring $QDK_GPG_PUBKEYRING --detach-sign -o-"
 			[ -n "$QDK_GPG_NAME" ] && gpg_options="$gpg_options -u $QDK_GPG_NAME"
 			is_quiet && gpg_options="$gpg_options --no-tty"
 			gpg_cmd="$QDK_GPG_APP $gpg_options ${qpkg}.$$ >> ${qpkg}.sig"
 			debug_msg "$gpg_cmd"
-			eval $gpg_cmd || warn_msg "${qpkg##*/}: no signature added"
+			if ! eval $gpg_cmd || [ ! -s ${qpkg}.sig ]; then
+				/bin/rm -f ${qpkg}.$$ ${qpkg}.sig
+				err_msg "${qpkg##*/}: no signature added"
+			fi
 
 			add_qdk_area_begin ${qpkg}.$$
 			add_qdk_area_signature ${qpkg}.sig ${qpkg}.$$
@@ -2141,15 +2144,15 @@ usage: $(/usr/bin/basename $0) [--extract QPKG [DIR]] [--create-env NAME] [-s|--
 	  conflict	list conflicting packages
 	  funcs		output package specific functions
 --sign
-	Generate and insert digital signature to QPKG. By default the first key
-	in the secret keyring is used.
+	Generate and insert digital signature to QPKG using the public keyring
+	specified by QDK_GPG_PUBKEYRING (default: /etc/config/qpkg.gpg).
 --gpg-name ID
 	Use specified user ID to sign QPKG.
 --verify QPKG
 	Verify digital signature assigned to QPKG.
 --add-sign QPKG
 	Generate and insert digital signature to QPKG, replacing any existing
-	signature.
+	signature. Uses QDK_GPG_PUBKEYRING in the same way as --sign.
 --import-key KEY
 	Import ASCII armored key to public keyring.
 --list-keys


### PR DESCRIPTION
There is an inconsistency in how `qbuild` uses the GPG keyring across different commands.

The following commands already use the configured GPG keyring file `QDK_GPG_PUBKEYRING`:
`--import-key` `--list-keys` `--verify`

However, the following signing commands were still using the default GPG keyring:
`--sign` `--add-sign`

This could cause signing and verification to use different keyrings, leading to unexpected signature issues.

Changes
- Use the configured GPG public keyring when generating QPKG signatures for both `--sign` and `--add-sign` by adding:
  - `--no-default-keyring`
  - `--keyring $QDK_GPG_PUBKEYRING`
- Make `--add-sign` fail fast if GPG fails to generate a valid `${qpkg}.sig`, preventing the command from continuing into the QPKG rewrite path with a missing or empty signature.
- Update `qbuild` help text and the Debian manpage to document that `--sign` and `--add-sign` depend on `QDK_GPG_PUBKEYRING`.
- Update `InstallToUbuntu.sh` uninstall cleanup to remove `/bin/qpkg_encrypt`.

Result
- Aligns the keyring behavior of import, list, verify, sign, and add-sign.
- Avoids mismatches between signing and verification.
- Remove command cleaned up all installed files.