### PR TITLE
fix(qbuild): preserve full version while truncating binary qpkg tail

### DIFF
--- a/package_routines
+++ b/package_routines
@@ -4,11 +4,8 @@ PKG_MAIN_REMOVE="{
 	$CMD_RM -f $QDK_CONF
 }"
 
-pkg_init(){
-	add_qpkg_config $QDK_CONF 0
-}
-
 pkg_install(){
+	add_qpkg_config $QDK_CONF 0
 	if [ -f "$QDK_CONF" ]; then
 		$CMD_SED -i "s!\(QDK_VERSION=\).*!\1$QPKG_VER!" $QDK_CONF
 		$CMD_SED -i "s!\(QDK_PATH=\).*!\1$SYS_QPKG_DIR!" $QDK_CONF

--- a/shared/bin/qbuild
+++ b/shared/bin/qbuild
@@ -1099,7 +1099,11 @@ add_qpkg_tail(){
 	pad_field _QPKG_MODEL
 	_QPKG_NAME="$QPKG_NAME_SHORTER"
 	pad_field _QPKG_NAME 20
-	_QPKG_VERSION="$QPKG_VER"
+	local tail_ver
+	tail_ver=$(echo "$QPKG_VER" | cut -d. -f1-3)
+	[ ${#tail_ver} -le 10 ] || tail_ver=$(/usr/bin/expr substr "$tail_ver" 1 10)
+	[ "$tail_ver" = "$QPKG_VER" ] || verbose_msg "QPKG tail version set to $tail_ver (full version $QPKG_VER preserved in qpkg.cfg)"
+	_QPKG_VERSION="$tail_ver"
 	pad_field _QPKG_VERSION
 	printf "${_QPKG_MODEL}${space_50}${_QPKG_NAME}${_QPKG_VERSION}${flag}" >> $QDK_QPKG_FILE
 	debug_msg "${_QPKG_MODEL}${space_50}${_QPKG_NAME}${_QPKG_VERSION}${flag}"
@@ -1296,18 +1300,13 @@ truncate_qpkg_name(){
 	fi
 }
 
-# Handle max lenght and any space in version; anything after a space is removed.
+# Handle any space in version; anything after a space is removed.
+# Full version (including build number) is preserved in qpkg.cfg.
+# The binary tail uses only major.minor.patch to fit the 10-char field.
 truncate_qpkg_version(){
 	if [ "$QPKG_VER" != "${QPKG_VER%% *}" ]; then
 		warn_msg "QPKG_VER: space is not allowed; value truncated."
 		edit_qpkg_config QPKG_VER "${QPKG_VER%% *}"
-	fi
-
-	local max_qpkg_ver_len=10
-	if [ $max_qpkg_ver_len -lt ${#QPKG_VER} ]; then
-		warn_msg "QPKG_VER: the length of $QPKG_VER must be less than or equal to $max_qpkg_ver_len; value truncated."
-		QPKG_VER=$(/usr/bin/expr substr "$QPKG_VER" 1 $max_qpkg_ver_len)
-		edit_qpkg_config QPKG_VER "$QPKG_VER"
 	fi
 }
 


### PR DESCRIPTION
Keep the full QPKG version in qpkg.cfg while constraining the on-disk tail version to major.minor.patch for the 10-character field.