### PR TITLE
fix(scripts): use /etc/default_config for uLinux.conf

### DIFF
--- a/shared/bin/qbuild
+++ b/shared/bin/qbuild
@@ -28,6 +28,7 @@
 
 ##### System definitions #####
 PREFIX="App Center"
+DEFAULT_ULINUX_CONF="/etc/default_config/uLinux.conf"
 
 ##### Command definitions #####
 CMD_AWK="${CMD_AWK:-$(command -v awk)}"
@@ -37,7 +38,7 @@ if [ ! -e "$CS_PYTHON" ]; then
 CS_PYTHON="/usr/local/bin/python2"
 fi
 
-if [ -f "/etc/config/uLinux.conf" ]; then
+if [ -f "$DEFAULT_ULINUX_CONF" ]; then
     IS_NAS="TRUE"
 else
     IS_NAS="FALSE"

--- a/shared/scripts/qinstall.sh
+++ b/shared/scripts/qinstall.sh
@@ -79,6 +79,7 @@ SYS_QPKG_DATA_BUILTVER_FILE="./built_version"
 SYS_QPKG_DATA_BUILTINFO_FILE="./built_info"
 SYS_QPKG_DATA_PACKAGES_FILE="./Packages.gz"
 SYS_QPKG_CONFIG_FILE="$SYS_CONFIG_DIR/qpkg.conf"
+SYS_DEFAULT_ULINUX_CONF="/etc/default_config/uLinux.conf"
 SYS_QPKG_CONF_FIELD_QPKGFILE="QPKG_File"
 SYS_QPKG_CONF_FIELD_NAME="Name"
 SYS_QPKG_CONF_FIELD_DISPLAY_NAME="Display_Name"
@@ -511,7 +512,7 @@ remove_file_and_empty_dir(){
 # Check QTS minimum version.
 #############################
 check_qts_version(){
-	local now_version=`/sbin/getcfg System Version -f /etc/config/uLinux.conf`
+	local now_version=`/sbin/getcfg System Version -f "$SYS_DEFAULT_ULINUX_CONF"`
 
 	if [ -n "$QTS_MINI_VERSION" ] && is_less "$now_version" "$QTS_MINI_VERSION"; then
 		if [ -x "/usr/local/sbin/notify" ]; then


### PR DESCRIPTION
## Summary
- update shared/bin/qbuild to detect NAS by reading /etc/default_config/uLinux.conf
- update shared/scripts/qinstall.sh to read QTS version from /etc/default_config/uLinux.conf
- align both scripts with the HA config path split

## Testing
- not run (not requested)