### PR TITLE
feat: add Distribution_Type support for QPKG metadata

### DIFF
--- a/shared/scripts/qinstall.sh
+++ b/shared/scripts/qinstall.sh
@@ -106,6 +106,7 @@ SYS_QPKG_CONF_FIELD_PROXY_PATH="Proxy_Path"
 SYS_QPKG_CONF_FIELD_TIMEOUT="Timeout"
 SYS_QPKG_CONF_FIELD_VISIBLE="Visible"
 SYS_QPKG_CONF_FIELD_FORCE_VISIBLE="Force_Visible"
+SYS_QPKG_CONF_FIELD_DISTRIBUTION_TYPE="Distribution_Type"
 SYS_QPKG_CONF_FIELD_CONTAINER="Container"
 SYS_QPKG_CONF_FIELD_EXEC_FILES="Exec_Files"
 SYS_QPKG_CONF_FIELD_FW_VER_MIN="FW_Ver_Min"
@@ -812,6 +813,9 @@ set_qpkg_force_visible(){
 		set_qpkg_field $SYS_QPKG_CONF_FIELD_FORCE_VISIBLE "$QPKG_FORCE_VISIBLE"
 	fi
 }
+set_qpkg_distribution_type(){
+	set_qpkg_field $SYS_QPKG_CONF_FIELD_DISTRIBUTION_TYPE "${QPKG_DISTRIBUTION_TYPE:-0}"
+}
 set_qpkg_fw_ver_min(){
 	if [ -n "$QTS_MINI_VERSION" ]; then
 		set_qpkg_field $SYS_QPKG_CONF_FIELD_FW_VER_MIN "$QTS_MINI_VERSION"
@@ -950,6 +954,7 @@ register_qpkg(){
 	set_qpkg_timeout
 	set_qpkg_visible
 	set_qpkg_force_visible
+	set_qpkg_distribution_type
 	set_qpkg_container
 	set_qpkg_exec_file
 	set_qpkg_fw_ver_min

--- a/shared/template/qpkg.cfg
+++ b/shared/template/qpkg.cfg
@@ -1,6 +1,6 @@
 # Name of the packaged application.
 QPKG_NAME=""
-# Name of the display application.
+# Display name shown on QTS Web UI (defaults to QPKG_NAME if not set).
 #QPKG_DISPLAY_NAME=""
 # Version of the packaged application. 
 QPKG_VER="0.1"
@@ -13,18 +13,17 @@ QPKG_AUTHOR=""
 
 # Preferred number in start/stop sequence.
 QPKG_RC_NUM="101"
-# Init-script used to control the start and stop of the installed application.
+# Path to the shell script for starting and stopping the application (shows start/stop button in App Center).
 QPKG_SERVICE_PROGRAM=""
 
-# Optional 1 is enable. Path of starting/ stopping shall script. (no start/stop on App Center)
+# When set to 1, hides the start/stop button in App Center while still running the service script on enable/disable.
 #QPKG_DISABLE_APPCENTER_UI_SERVICE=1
 
 # Specifies any packages required for the current package to operate.
 #QPKG_REQUIRE="Python >= 2.7"
 # Replace the QPKG_REQUIRE message displayed in the system log
 #QPKG_REQUIRE_MSG=""
-# Specifies what packages cannot be installed if the current package
-# is to operate properly.
+# Specifies packages that conflict with this package and cannot be installed simultaneously.
 #QPKG_CONFLICT="Python"
 # Name of configuration file (multiple definitions are allowed).
 #QPKG_CONFIG="myApp.conf"
@@ -40,39 +39,40 @@ QPKG_SERVICE_PROGRAM=""
 # Port number for the SSL web interface.
 #QPKG_WEB_SSL_PORT=""
 
-# Use QTS HTTP Proxy and set Proxy_Path in the qpkg.conf. 
-# When the QPKG has its own HTTP service port, and want clients to connect via QTS HTTP port (default 8080).
-# Usually use this option when the QPKG need to connect via myQNAPcloud service.
+# Enable QTS HTTP Proxy so clients connect to the QPKG via the QTS HTTP port (default 8080).
+# Useful when the QPKG has its own HTTP service port but needs to be reachable via myQNAPcloud.
 #QPKG_USE_PROXY="1"
 #QPKG_PROXY_PATH="/qpkg_name"
 
-#Desktop Application (since 4.1)
-# Set value to 1 means to open the QPKG's Web UI inside QTS desktop instead of new window.
+# Desktop Application (since QTS 4.1)
+# Controls how the QPKG Web UI is opened: 0=new browser tab, 1=iFrame on QTS desktop, 2=desktop only (since QTS 4.4.1).
 #QPKG_DESKTOP_APP="1"
-# Desktop Application Window default inner width (since 4.1) (not over 1178)
+# Default inner width of the desktop application window (since QTS 4.1, max: 1178).
 #QPKG_DESKTOP_APP_WIN_WIDTH=""
-# Desktop Application Window default inner height (since 4.1) (not over 600)
+# Default inner height of the desktop application window (since QTS 4.1, max: 600).
 #QPKG_DESKTOP_APP_WIN_HEIGHT=""
 
 # Minimum QTS version requirement
 QTS_MINI_VERSION="4.1.0"
 
-# Select volume
-# 1: support installation
-# 2: support migration
-# 3 (1+2): support both installation and migration
+# Target volume for installation or migration.
+# 0: use default volume (no selection prompt)
+# 1: support installation to a selected volume
+# 2: support migration to a selected volume
+# 3 (1+2): support both installation and migration to a selected volume
+# 4: support installation to a selected volume without a default volume
 #QPKG_VOLUME_SELECT="0"
 
-# Set timeout for QPKG enable and QPKG disable (since 4.1.0)
-# Format in seconds (enable, disable)
+# Timeout in seconds for starting and stopping the QPKG service (since QTS 4.1.0).
+# Format: "start_timeout,stop_timeout"
 #QPKG_TIMEOUT="10,30"
 
-# Visible setting for the QPKG that has web UI, show this QPKG on the Main menu of 
-# 1(default): administrators, 2: all NAS users.
+# Controls which users see this QPKG in the QTS Main menu (requires QPKG_WEBUI to be set).
+# 0: admin only, 1(default): administrators, 2: all NAS users.
 #QPKG_VISIBLE="2"
 
-# Make the QPKG be visible only for
-# 1: administrators, 2: all NAS users, 3(default): No limit
+# Overrides QPKG_VISIBLE to restrict who can see this QPKG.
+# 1: administrators only, 2: all NAS users, 3(default): no restriction (follow QPKG_VISIBLE).
 #QPKG_FORCE_VISIBLE="3"
 
 # Distribution type for compatibility checks
@@ -80,15 +80,15 @@ QTS_MINI_VERSION="4.1.0"
 # 1: QPKG updates are not published via PGM-maintained XML
 #QPKG_DISTRIBUTION_TYPE="0"
 
-# Storage share folder add/delete action
+# Callback script invoked after a shared folder is created / before a shared folder is removed.
 #QPKG_SHARE_ADD_ACTION=""
 #QPKG_SHARE_DEL_ACTION=""
 
-# Storage mount/unmount action
+# Callback script invoked after a volume is mounted / before a volume is unmounted.
 #QPKG_MOUNT_ACTION=""
 #QPKG_UNMOUNT_ACTION=""
 
-# Register action volume status into read delete or read only mode
+# Callback script invoked before a volume enters / after a volume leaves Read/Delete mode.
 #QPKG_ENTER_READDELETE_ACTION=""
 #QPKG_LEAVE_READDELETE_ACTION=""
 
@@ -105,7 +105,7 @@ QTS_MINI_VERSION="4.1.0"
 #QPKG_ENTER_HERO_CRITICAL_LOW_ACTION=""
 #QPKG_LEAVE_HERO_CRITICAL_LOW_ACTION=""
 
-# Default timeout is 15 sec, if without this option
+# Timeout in seconds for action callbacks above. Defaults to 15 seconds if not set.
 #QPKG_ACTION_TIMEOUT=""
 
 # For QNAP code signing (currently can be done only inside QNAP)

--- a/shared/template/qpkg.cfg
+++ b/shared/template/qpkg.cfg
@@ -75,6 +75,11 @@ QTS_MINI_VERSION="4.1.0"
 # 1: administrators, 2: all NAS users, 3(default): No limit
 #QPKG_FORCE_VISIBLE="3"
 
+# Distribution type for compatibility checks
+# 0(default): QPKG updates are published via PGM-maintained XML
+# 1: QPKG updates are not published via PGM-maintained XML
+#QPKG_DISTRIBUTION_TYPE="0"
+
 # Storage share folder add/delete action
 #QPKG_SHARE_ADD_ACTION=""
 #QPKG_SHARE_DEL_ACTION=""


### PR DESCRIPTION
## Summary
- add `QPKG_DISTRIBUTION_TYPE` to the QPKG template and document the supported values
- write `Distribution_Type` into installed `qpkg.conf` during QPKG registration
- default the registered value to `0` when the new template field is not set

## Why
App Center needs to distinguish QPKGs that are distributed through the
PGM-maintained XML feed from packages that are delivered outside that
channel, so compatibility prompts can skip the latter.

## Impact
Existing packages keep the current behavior by registering
`Distribution_Type=0` by default.
Packages that should be excluded from XML-based compatibility checks can
set `QPKG_DISTRIBUTION_TYPE="1"`.

## Validation
- `sh -n shared/scripts/qinstall.sh`
- `bash -n shared/bin/qbuild`
